### PR TITLE
(fix): add authors to publication manually

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -81,6 +81,7 @@ x-shared-field-definitions:
       value_field: slug
       display_fields: [name]
       required: false
+      options_length: 50
     projects: &projects
       name: projects
       label: Associated projects

--- a/content/publications/rxm8b67cdfu7mnli1wp46/data.yaml
+++ b/content/publications/rxm8b67cdfu7mnli1wp46/data.yaml
@@ -23,3 +23,10 @@ authors:
   - morgan-l-turner
   - so-jin-kim
   - patty-j-lee
+  - josh-bartz
+  - sergii-domanskyi
+  - samual-t-peters
+  - archibald-enninful
+  - negin-farzad
+  - rong-fan
+  - bruce-w-herr-ii


### PR DESCRIPTION
# Summary
- The CMS currently does not allow our colleagues to add more than 20 authors to a publication. As users are adding more authors tags, the dropdown in the CMS UI no longer displays further options, with an empty list state and `No options` text.
- Due to this, I just edited the YAML file, but it would be best if this functioned correctly.
- This is the current workaround for #146
- Experimenting with adding `options_length: 50` to config.yml